### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dhgibbs.visualstudio.com/5f86226b-53b2-499e-b36b-f2bdc497858a/ed82e67a-2fc5-4046-aa7e-19b846541939/_apis/work/boardbadge/b407155a-ad4b-4291-b42f-83881cced1b5)](https://dhgibbs.visualstudio.com/5f86226b-53b2-499e-b36b-f2bdc497858a/_boards/board/t/ed82e67a-2fc5-4046-aa7e-19b846541939/Microsoft.RequirementCategory)
 # Landing-Hub-Web
 This application is used as the Landing Hub for vistors to my domain.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#19](https://dhgibbs.visualstudio.com/5f86226b-53b2-499e-b36b-f2bdc497858a/_workitems/edit/19). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.